### PR TITLE
Rename didEndDecelerating to didUpdateVisibleIndices.

### DIFF
--- a/CollectionGraph/CollectionGraphDelegate.swift
+++ b/CollectionGraph/CollectionGraphDelegate.swift
@@ -12,22 +12,30 @@ class CollectionGraphDelegate: NSObject, UICollectionViewDelegate {
     
     let collectionView: UICollectionView
     
-    internal var didEndDeceleratingCallback: ((_ indexPaths: [IndexPath]) -> ())?
+    var visibleIndices = Set<IndexPath>() {
+        didSet {
+            let sections = visibleIndices.map {
+                $0.section
+            }
+            
+            let sectionSet = Set<Int>(sections)
+            
+            didUpdateVisibleIndicesCallback?(visibleIndices, sectionSet)
+        }
+    }
+    
+    internal var didUpdateVisibleIndicesCallback: ((_ indexPaths: Set<IndexPath>, _ sections: Set<Int>) -> ())?
     
     public init(_ collectionView: UICollectionView) {
         self.collectionView = collectionView
     }
     
-    internal func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
-        didEndDeceleratingCallback?(collectionView.indexPathsForVisibleItems)
+    func collectionView(_ collectionView: UICollectionView, willDisplay cell: UICollectionViewCell, forItemAt indexPath: IndexPath) {
+        visibleIndices.insert(indexPath)
     }
     
-    internal func scrollViewDidEndScrollingAnimation(_ scrollView: UIScrollView) {
-        didEndDeceleratingCallback?(collectionView.indexPathsForVisibleItems)
-    }
-    
-    internal func scrollViewDidEndDragging(_ scrollView: UIScrollView, willDecelerate decelerate: Bool) {
-        didEndDeceleratingCallback?(collectionView.indexPathsForVisibleItems)
+    func collectionView(_ collectionView: UICollectionView, didEndDisplaying cell: UICollectionViewCell, forItemAt indexPath: IndexPath) {
+        visibleIndices.remove(indexPath)
     }
     
 }

--- a/CollectionGraph/CollectionGraphView.swift
+++ b/CollectionGraph/CollectionGraphView.swift
@@ -221,8 +221,8 @@ public class CollectionGraphView: UIView, UICollectionViewDelegate {
     /**
      Callback that returns the visible IndexPaths when scrolling stops
     */
-    public func didEndDecelerating(callback: @escaping (_ indexPaths: [IndexPath]) -> ()) {
-        collectionGraphDelegate.didEndDeceleratingCallback = callback
+    public func didUpdateVisibleIndices(callback: @escaping (_ indexPaths: Set<IndexPath>, _ sections: Set<Int>) -> ()) {
+        collectionGraphDelegate.didUpdateVisibleIndicesCallback = callback
     }
     
     /**

--- a/CollectionGraphExample/FirstViewController.swift
+++ b/CollectionGraphExample/FirstViewController.swift
@@ -56,7 +56,7 @@ class FirstViewController: UIViewController {
             self.graph.contentOffset = CGPoint(x: 30, y: self.graph.contentOffset.y)
         })
 
-        graph.didEndDecelerating { (indexPaths) in
+        graph.didUpdateVisibleIndices { (indexPaths, sections) in
             indexPaths.forEach {
                 let data = self.graph.graphData?[$0.section][$0.item]
                 print("Data: \(data)")


### PR DESCRIPTION
Pass along visible indices and sections.
Call didUpdateVisibleIndices every time a cell is inserted or removed.