### PR TITLE
Call setNeedsLayout() during apply() to make sure the line is re-drawn.

### DIFF
--- a/CollectionGraph/LineConnectorView.swift
+++ b/CollectionGraph/LineConnectorView.swift
@@ -34,15 +34,11 @@ class LineConnectorView: UICollectionReusableView {
         layer.addSublayer(line)
     }
 
-    override func prepareForReuse() {
-        super.prepareForReuse()
-        lineStartsAtTop = true
-    }
-
     override func apply(_ layoutAttributes: UICollectionViewLayoutAttributes) {
         super.apply(layoutAttributes)
         if let attributes = layoutAttributes as? LineConnectorAttributes {
             self.lineStartsAtTop = attributes.lineStartsAtTop
+            setNeedsLayout()
         }
     }
 


### PR DESCRIPTION
Remove prepareForReuse() since apply() should be providing all the info that is needed.